### PR TITLE
Grid tariff unit

### DIFF
--- a/custom_components/elvia/sensor.py
+++ b/custom_components/elvia/sensor.py
@@ -498,7 +498,7 @@ class ElviaEnergyFixedLinkSensor(ElviaValueSensor):
 
         self._attr_state_class = SensorStateClass.TOTAL
         self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_native_unit_of_measurement = "NOK"
+        self._attr_native_unit_of_measurement = "NOK/kWh"
 
         self._attr_extra_state_attributes = {
             "start_time": None,
@@ -512,7 +512,7 @@ class ElviaEnergyFixedLinkSensor(ElviaValueSensor):
         if period is None:
             return
 
-        self._attr_native_value = period.cost
+        self._attr_native_value = period.cost / 100.0
 
         periods = elvia.get_cost_periods()
         day_period: CostTimeSpan = periods["day"]


### PR DESCRIPTION
* Specify unit of measurement as _NOK per kWh_ to be compatible with Home Assistant's [Energy dashboard](https://www.home-assistant.io/blog/2021/08/04/home-energy-management/)
* Correct the currency level as the tariff price is provided in _øre_