### PR TITLE
Handle delayed meter readings

### DIFF
--- a/custom_components/elvia/manifest.json
+++ b/custom_components/elvia/manifest.json
@@ -3,13 +3,14 @@
   "name": "elvia",
   "version": "0.5.7-beta",
   "config_flow": true,
-  "documentation": "https://www.home-assistant.io/integrations/elvia",
-  "requirements": ["pyElvia>=0.0.8"],
+  "documentation": "https://github.com/bskjon/ha_elvia",
+  "issue_tracker": "https://github.com/bskjon/ha_elvia/issues",
+  "requirements": ["pyElvia>=0.0.9"],
 
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
   "codeowners": ["@bskjon"],
-  "iot_class": "local_polling"
+  "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
Waits until 01.30 at night to start requesting the next day, as meter readings in the API are delayed with a minimum of ~1 hour. Resolves #3, so a full day of consumption is recorded before reseting the statistics.