### PR TITLE
Handle empty meter readings

### DIFF
--- a/custom_components/elvia/sensor.py
+++ b/custom_components/elvia/sensor.py
@@ -470,6 +470,18 @@ class ElviaMeterReadingLevelSensor(ElviaMeterSensor):
         _LOGGER.debug("Hourly consumption from {} to {}".format(
             _meter_values.fromHour, _meter_values.toHour))
 
+        # Guard for empty responses on a date with previous data
+        if (len(_meter_values.timeSeries) == 0 and (self._attr_native_value is not None and self._attr_native_value > 0.0)):
+            _response_date = datetime.fromisoformat(_meter_values.fromHour).replace(
+                hour=0, minute=0, second=0, microsecond=0)
+            _recorded_date = datetime.fromisoformat(self._attr_extra_state_attributes.get("start_time")).replace(
+                hour=0, minute=0, second=0, microsecond=0) 
+            _LOGGER.debug("Empty response detected for {:%Y-%m-%d}. Records exists for {:%Y-%m-%d}".format(_response_date, _recorded_date))
+            if (_response_date == _recorded_date):
+                _LOGGER.warning(
+                    "Ignoring empty response for day with previous data")
+                return
+
         # Sort hours chronological
         _time_series = sorted(_meter_values.timeSeries,
                               key=lambda series: series.startTime)


### PR DESCRIPTION
Ignores empty responses from Elvia's API if a day previously has received measurements. Resolves #5, so statistics is not erroneously reset in the middle of a day.